### PR TITLE
[Fix #4] missing styled items in lists

### DIFF
--- a/src/custom_html_part.ts
+++ b/src/custom_html_part.ts
@@ -15,7 +15,7 @@ export interface CustomHtmlPart {
    * ```typescript
    * class MyCustomBlock implements CustomHtmlPart {
    *   matches(element: DomElement): boolean {
-   *     return element.tagName === 'div' && element.attribs.class === 'my-custom-class';
+   *     return element.localName === 'div' && element.attribs.class === 'my-custom-class';
    *   }
    * }
    * ```

--- a/src/html_to_operation.ts
+++ b/src/html_to_operation.ts
@@ -1,4 +1,4 @@
-import { HTMLElement } from 'node-html-parser';
+import { HTMLElement, Node } from 'node-html-parser';
 import Delta, { Op } from 'quill-delta';
 import { CustomHtmlPart } from './custom_html_part';
 import {
@@ -43,7 +43,7 @@ export abstract class HtmlOperations {
     nextIsBlock: Boolean = false,
   ): Op[] {
     let ops: Op[] = [];
-    if (!element.tagName) {
+    if (!element.localName) {
       ops.push({ insert: element.text || '' });
       return ops;
     }
@@ -52,12 +52,12 @@ export abstract class HtmlOperations {
     // the current element could be into a <li> then it's node can be
     // a <strong> or a <em>, or even a <span> then we first need to verify
     // if a inline an store into it to parse the attributes as we need
-    if (isInline(element.tagName)) {
+    if (isInline(element.localName)) {
       const delta = new Delta();
       const attributes = getInlineAttributes(element);
       for (let index = 0; index < element.childNodes.length; index++) {
         const node = element.childNodes.at(index);
-        if (node instanceof HTMLElement) {
+        if (node instanceof Node) {
           processNode(node, attributes, delta, false, this.customBlocks);
         }
       }

--- a/src/html_utils.ts
+++ b/src/html_utils.ts
@@ -6,12 +6,12 @@ import { parseToPx } from './fontsize_parser';
 
 export function getInlineAttributes(element: HTMLElement): AttributeMap {
   const attributes: AttributeMap = {};
-  if (element.tagName === 'strong') attributes.bold = true;
-  if (element.tagName === 'em') attributes.italic = true;
-  if (element.tagName === 'u') attributes.underline = true;
-  if (element.tagName === 's') attributes.strike = true;
-  if (element.tagName === 'sub') attributes.script = 'sub';
-  if (element.tagName === 'sup') attributes.script = 'super';
+  if (element.localName === 'strong') attributes.bold = true;
+  if (element.localName === 'em') attributes.italic = true;
+  if (element.localName === 'u') attributes.underline = true;
+  if (element.localName === 's') attributes.strike = true;
+  if (element.localName === 'sub') attributes.script = 'sub';
+  if (element.localName === 'sup') attributes.script = 'super';
   return attributes;
 }
 


### PR DESCRIPTION
## What does this PR do?

- Fix #4. In `resolveCurrentElement` for inline cases:
  1. Correct a case mismatch caused by using `HTMLElement.tagName` (returns uppercase) by switching to `HTMLElement.localName` (returns lowercase)
  2. Replace the `instanceof HTMLElement` check with processing of all `Node` instances, so text content isn't skipped.


## What tests have been done?

```typescript
import { HtmlToDelta } from 'quill-delta-from-html';

const html = `
<ul>
  <li>Unstyled Item</li>
  <li><strong>Bold Item</strong></li>
  <li><em>Italic Item</em></li>
</ul>
`;

const delta = new HtmlToDelta().convert(html);
console.log(JSON.stringify(delta));
```

Output:

```json
{
  "ops": [
    {
      "insert": "Unstyled Item"
    },
    {
      "insert": "\n",
      "attributes": {
        "list": "bullet"
      }
    },
    {
      "insert": "Bold Item",
      "attributes": {
        "bold": true
      }
    },
    {
      "insert": "\n",
      "attributes": {
        "list": "bullet"
      }
    },
    {
      "insert": "Italic Item",
      "attributes": {
        "italic": true
      }
    },
    {
      "insert": "\n",
      "attributes": {
        "list": "bullet"
      }
    },
    {
      "insert": "\n"
    }
  ]
}
```