### PR TITLE
[Fix #7] CustomHtmlPart not parsed when nested inside other elements

### DIFF
--- a/src/node_processor.ts
+++ b/src/node_processor.ts
@@ -162,7 +162,7 @@ export function processNode(
 
     // Recursively process child nodes
     for (let child of node.childNodes) {
-      processNode(child, newAttributes, delta, addSpanAttrs);
+      processNode(child, newAttributes, delta, addSpanAttrs, customBlocks);
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

- Fix #7. In `processNode`, pass `customBlocks` recusively.


## What tests have been done?

```typescript
import { HtmlToDelta, CustomHtmlPart } from 'quill-delta-from-html';
import { AttributeMap, Op } from 'quill-delta';
import { HTMLElement } from 'node-html-parser';

class FormulaHtmlPart implements CustomHtmlPart {
  tagName = 'span';
  attribute = { class: 'latex' };

  matches(element: HTMLElement): boolean {
    return element.rawTagName === this.tagName && element.getAttribute('class') === 'latex';
  }

  convert(element: HTMLElement, currentAttributes?: AttributeMap): Op[] {
    const latex = element.textContent || '';

    return [
      { insert: { formula: latex }, attributes: currentAttributes, }
    ];
  }
}

const html = `
<p>Unstyled line with <span class="latex">\\nabla f</span> CustomHtmlPart</p>
<p><strong>Styled line with <span class="latex">\\nabla f</span> CustomHtmlPart</strong></p>
`

const delta = new HtmlToDelta([new FormulaHtmlPart()]).convert(html);
console.log(JSON.stringify(delta));
```

Output:

```json
{
  "ops": [
    {
      "insert": "Unstyled line with "
    },
    {
      "insert": {
        "formula": "\\nabla f"
      }
    },
    {
      "insert": " CustomHtmlPart"
    },
    {
      "insert": "Styled line with ",
      "attributes": {
        "bold": true
      }
    },
    {
      "insert": {
        "formula": "\\nabla f"
      }
    },
    {
      "insert": " CustomHtmlPart",
      "attributes": {
        "bold": true
      }
    },
    {
      "insert": "\n"
    }
  ]
}
```